### PR TITLE
feat: support stream insertion in either direction

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:async_list_view/async_list_view.dart';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'mock_database.dart';

--- a/lib/async_list_view.dart
+++ b/lib/async_list_view.dart
@@ -1,2 +1,2 @@
 export 'package:async_list_view/src/async_list_view.dart'
-    show AsyncListView, IndexedSnapshotWidgetBuilder;
+    show AsyncListView, IndexedSnapshotWidgetBuilder, InsertionDirection;

--- a/lib/src/async_list_view.dart
+++ b/lib/src/async_list_view.dart
@@ -245,6 +245,7 @@ class _AsyncListViewState<T> extends State<AsyncListView<T>> {
         if (index > 0 && !streamShouldBeRunning) {
           _pauseStream();
         } else if (index == 0) {
+          streamShouldBeRunning = true;
           _resumeStream();
         }
         return widget.itemBuilder(context, snapshot, index);

--- a/lib/src/async_list_view.dart
+++ b/lib/src/async_list_view.dart
@@ -7,7 +7,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_summary_builder/stream_summary_builder.dart';
 
-enum AsyncListViewInsertionDirection {
+enum InsertionDirection {
   /// Insert new items at the end of the list.
   end,
 
@@ -33,7 +33,7 @@ class AsyncListView<T> extends StatefulWidget {
     this.initialData,
     this.loadingWidget,
     this.noResultsWidgetBuilder,
-    this.insertionDirection = AsyncListViewInsertionDirection.end,
+    this.insertionDirection = InsertionDirection.end,
     // Generic ListView parameters.
     this.scrollDirection = Axis.vertical,
     this.reverse = false,
@@ -80,8 +80,8 @@ class AsyncListView<T> extends StatefulWidget {
   /// Which side of the initialData to insert new events into.
   /// This can be useful for situtions where the list is reversed in order to
   /// achieve a chat-like effect.
-  /// Defaults to [AsyncListViewInsertionDirection.end].
-  final AsyncListViewInsertionDirection insertionDirection;
+  /// Defaults to [InsertionDirection.end].
+  final InsertionDirection insertionDirection;
 
   /// The following attributes are all passed directly through to [ListView] as
   /// constructor arguments.
@@ -172,8 +172,7 @@ class _AsyncListViewState<T> extends State<AsyncListView<T>> {
       initialData: _listSoFar,
       fold: (lst, newValue) {
         final copiedList = List<T>.from(lst);
-        if (widget.insertionDirection ==
-            AsyncListViewInsertionDirection.beginning) {
+        if (widget.insertionDirection == InsertionDirection.beginning) {
           _listSoFar = copiedList..insert(0, newValue);
         } else {
           _listSoFar = copiedList..add(newValue);

--- a/lib/src/async_list_view.dart
+++ b/lib/src/async_list_view.dart
@@ -217,9 +217,10 @@ class _AsyncListViewState<T> extends State<AsyncListView<T>> {
       itemExtent: widget.itemExtent,
       itemBuilder: (context, index) {
         if (widget.insertionDirection == InsertionDirection.end) {
-          if (index < length) {
+          if (index < length && !streamShouldBeRunning) {
             _pauseStream();
           } else if (index >= length - 1) {
+            streamShouldBeRunning = true;
             _resumeStream();
           }
           if (index == _listSoFar.length && widget.loadingWidget != null) {

--- a/lib/src/async_list_view.dart
+++ b/lib/src/async_list_view.dart
@@ -193,7 +193,7 @@ class _AsyncListViewState<T> extends State<AsyncListView<T>> {
       return widget.noResultsWidgetBuilder!(context);
     }
 
-    final willShowLoadingWidget =
+    final shouldMakeSpaceForLoadingWidget =
         !(snapshot.connectionState == ConnectionState.done ||
             widget.loadingWidget == null);
 
@@ -229,7 +229,7 @@ class _AsyncListViewState<T> extends State<AsyncListView<T>> {
           return widget.itemBuilder(context, snapshot, index);
         }
 
-        if (willShowLoadingWidget) {
+        if (shouldMakeSpaceForLoadingWidget) {
           if (index > 1 && !streamShouldBeRunning) {
             _pauseStream();
           } else if (index == 1) {
@@ -250,7 +250,7 @@ class _AsyncListViewState<T> extends State<AsyncListView<T>> {
         return widget.itemBuilder(context, snapshot, index);
       },
       // Allow for an extra item in the list for the loading widget.
-      itemCount: willShowLoadingWidget ? length + 1 : length,
+      itemCount: shouldMakeSpaceForLoadingWidget ? length + 1 : length,
       addAutomaticKeepAlives: widget.addAutomaticKeepAlives,
       addRepaintBoundaries: widget.addRepaintBoundaries,
       addSemanticIndexes: widget.addSemanticIndexes,

--- a/test/async_list_view_test.dart
+++ b/test/async_list_view_test.dart
@@ -117,6 +117,7 @@ void main() {
     await _iterativePump(tester, 5);
 
     expect(loaded, 5);
+
     final List<_Item> items =
         tester.widgetList<_Item>(find.byType(_Item)).toList();
 

--- a/test/async_list_view_test.dart
+++ b/test/async_list_view_test.dart
@@ -35,7 +35,8 @@ void main() {
           loadingWidget: const Text('loading'),
           initialData: initialData,
           insertionDirection: insertionDirection,
-          itemBuilder: (context, snap, index) => _Item(text: 'item$index'),
+          itemBuilder: (context, snap, index) =>
+              _Item(text: 'item${snap.data![index]}'),
         ),
       ),
     );

--- a/test/async_list_view_test.dart
+++ b/test/async_list_view_test.dart
@@ -6,6 +6,7 @@ void main() {
   Widget _boilerPlate({
     int itemCount = 1000,
     VoidCallback? onLoaded,
+    List<int> initialData = const [],
   }) {
     return Directionality(
       textDirection: TextDirection.ltr,
@@ -17,6 +18,7 @@ void main() {
             return i;
           }),
           loadingWidget: const Text('loading'),
+          initialData: initialData,
           itemBuilder: (context, snap, index) {
             return SizedBox(
               height: 10,
@@ -33,14 +35,14 @@ void main() {
     int loaded = 0;
     await tester.pumpWidget(_boilerPlate(onLoaded: () => loaded++));
     expect(loaded, 0);
-    expect(find.text('item1'), findsNothing);
+    expect(find.text('item0'), findsNothing);
     expect(find.text('loading'), findsOneWidget);
 
     // Wait for 5 items to load.
     await tester.pump(const Duration(milliseconds: 5));
     expect(loaded, 5);
     expect(find.text('item1'), findsOneWidget);
-    expect(find.text('item6'), findsNothing);
+    expect(find.text('item5'), findsNothing);
     expect(find.text('loading'), findsOneWidget);
 
     // Only as many items as are visible should load.
@@ -66,6 +68,21 @@ void main() {
     expect(find.text('item50'), findsOneWidget);
     expect(find.text('item60'), findsNothing);
     expect(find.text('loading'), findsNothing);
+
+    // Replace the async list view so that it disposes itself.
+    await tester.pumpWidget(Container());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('AsyncListView can present initial data',
+      (WidgetTester tester) async {
+    int loaded = 0;
+    await tester.pumpWidget(_boilerPlate(
+        itemCount: 5, onLoaded: () => loaded++, initialData: [0, 1, 2, 3, 4]));
+
+    expect(loaded, 0);
+    expect(find.text('item0'), findsOneWidget);
+    expect(find.text('item5'), findsNothing);
 
     // Replace the async list view so that it disposes itself.
     await tester.pumpWidget(Container());


### PR DESCRIPTION
# What and Why

To create a chat-like experience with lists, where new items are visually inserted at the bottom of the screen and push existing items up, I've found it's frequently recommended to reverse the order of the input list and set the ListView's property `reverse: true`. (i.e. [here](https://medium.com/@ximya/tips-and-tricks-for-implementing-a-successful-chat-ui-in-flutter-190cd81bdc64#:~:text=virtual%20keyboard%20appears.-,reversed%20property,-ListView.separated()) and [here](https://stackoverflow.com/questions/66352142/how-scroll-down-chat-list-view-when-open-the-chat-flutter))

This change allows enables the stream input to insert data at the opposite end of the list, to support this chat-like mechanism.

## Notes

This is my first time writing Flutter tests, coming from a Jest background - so do be please be nitty and highlight any way they could be written nicer/methods I could have leveraged.

It's also only my 6th month writing flutter in the occasional evening, so if this whole idea breaks with convention or isn't sensible, would love a chat as to why and how I could do things differently 😊

Cheers bud!